### PR TITLE
Linear fill optimization with distance transforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,9 +195,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -455,14 +455,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -724,12 +724,6 @@ dependencies = [
  "autocfg",
  "libm",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -1211,6 +1205,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+
+[[package]]
 name = "v_frame"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,20 +1333,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.59.0"
+name = "windows-link"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -1359,51 +1366,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console",
  "portable-atomic",
+ "rayon",
  "unicode-width",
  "unit-prefix",
  "web-time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2024"
 [dependencies]
 imageproc = { version = "0.25.0", features = ["display-window"] }
 ab_glyph = "0.2.29"
-indicatif = "0.17.11"
+indicatif = "0.18.0"
 rayon = "1.10.0"
 rstar = "0.12.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2024"
 [dependencies]
 imageproc = { version = "0.25.0", features = ["display-window"] }
 ab_glyph = "0.2.29"
-indicatif = "0.18.0"
+indicatif = {version = "0.18.0", features = ["rayon"]}
 rayon = "1.10.0"
 rstar = "0.12.2"

--- a/src/contour_line.rs
+++ b/src/contour_line.rs
@@ -127,10 +127,9 @@ pub fn find_contour_line_interval(
 
     // Identify the outer contour line
     let outer_contour_line = sorted_contour_lines
-        .iter()
+        .into_iter()
         .rev()
-        .find(|cl| cl.is_point_inside(&point))
-        .copied();
+        .find(|cl| cl.is_point_inside(&point));
 
     // Collect inner contour lines
     let inner_contour_lines = outer_contour_line.map_or(vec![], |outer| {

--- a/src/contour_line.rs
+++ b/src/contour_line.rs
@@ -50,15 +50,6 @@ impl ContourLine {
         hit_count % 2 == 1
     }
 
-    pub fn find_nearest_distance_squared(&self, point: &Point<usize>) -> f32 {
-        self.contour
-            .points
-            .iter()
-            .map(|p| distance_squared(point, p))
-            .min_by(|a, b| a.partial_cmp(b).unwrap())
-            .unwrap()
-    }
-
     pub fn contour(&self) -> &Contour<usize> {
         &self.contour
     }
@@ -175,17 +166,6 @@ pub fn find_contour_line_interval(
     }
 }
 
-pub fn find_nearest_distance_squared<'a>(
-    point: &Point<usize>,
-    contour_lines: &'a [&ContourLine],
-) -> f32 {
-    contour_lines
-        .iter()
-        .map(|cl| cl.find_nearest_distance_squared(point))
-        .min_by(|a, b| a.partial_cmp(b).unwrap())
-        .unwrap()
-}
-
 fn retain_outer<T>(contours: &mut Vec<Contour<T>>) {
     contours.retain(|c| c.border_type == BorderType::Outer);
 }
@@ -215,12 +195,6 @@ fn set_heights(tree: &mut RTree<ContourLine>) {
     for (cl, height) in tree.iter_mut().zip(heights) {
         cl.height = Some(height);
     }
-}
-
-fn distance_squared(a: &Point<usize>, b: &Point<usize>) -> f32 {
-    let dx = a.x as f32 - b.x as f32;
-    let dy = a.y as f32 - b.y as f32;
-    dx * dx + dy * dy
 }
 
 #[cfg(test)]

--- a/src/heightmap.rs
+++ b/src/heightmap.rs
@@ -418,7 +418,6 @@ impl Envelope {
     }
 }
 
-// TODO: Fix flood fill performance.
 fn flood_fill<T: Clone>(data: &mut [Vec<Option<T>>], x: usize, y: usize, replacement_value: T) {
     let w = data[0].len();
     let h = data.len();

--- a/src/heightmap.rs
+++ b/src/heightmap.rs
@@ -236,7 +236,7 @@ impl HeightMap {
     /// The algorithm is based on [Distance Transforms of Sampled Functions].
     ///
     /// This is not a direct use of [`imageproc::distance_transform::euclidean_squared_distance_transform`]
-    /// because more control is required.
+    /// because more control is required. And this implementation also takes advantage of parallel processing.
     ///
     /// This function calculates the distance from each pixel to the nearest outer or inner contour line,
     /// depending on the `distance_mode` parameter.
@@ -276,11 +276,6 @@ impl HeightMap {
 
         // Put these buffer outside the loop to avoid reallocating them every iteration
         // Be careful with these. If data are not overwrite correcctly, it may lead to incorrect results
-        let mut y_envelope = Envelope::new(h);
-        let mut y_result_buffer = vec![f32::NAN; h];
-        let mut x_envelope = Envelope::new(w);
-        let mut x_result_buffer = vec![f32::NAN; w];
-
         // Build feature and ignore maps for this height level
         let mut should_process = vec![vec![false; w]; h];
         let mut is_feature = vec![vec![false; w]; h];
@@ -290,42 +285,62 @@ impl HeightMap {
         while current_height <= self.max_height {
             let point_set = contour_point_sets.get(&current_height);
 
-            for y in 0..h {
-                for x in 0..w {
-                    let interval = interval_map[y][x].as_ref().unwrap();
+            // Parallelize the preprocessing step
+            should_process
+                .par_iter_mut()
+                .zip(is_feature.par_iter_mut())
+                .enumerate()
+                .for_each(|(y, (process_row, feature_row))| {
+                    for x in 0..w {
+                        let interval = interval_map[y][x].as_ref().unwrap();
 
-                    // Check if this pixel should be processed for this height level
-                    let process_pixel = match distance_mode {
-                        DistanceMode::ToInner => interval
-                            .inners()
-                            .first()
-                            .map_or(false, |inner| inner.height().unwrap() == current_height),
-                        DistanceMode::ToOuter => interval
-                            .outer()
-                            .map_or(false, |outer| outer.height().unwrap() == current_height),
+                        // Check if this pixel should be processed for this height level
+                        let process_pixel = match distance_mode {
+                            DistanceMode::ToInner => interval
+                                .inners()
+                                .first()
+                                .map_or(false, |inner| inner.height().unwrap() == current_height),
+                            DistanceMode::ToOuter => interval
+                                .outer()
+                                .map_or(false, |outer| outer.height().unwrap() == current_height),
+                        };
+
+                        process_row[x] = process_pixel;
+
+                        // Check if this pixel is a feature point
+                        let is_feature_point =
+                            process_pixel && point_set.map_or(false, |ps| ps.contains(&(x, y)));
+
+                        feature_row[x] = is_feature_point;
+                    }
+                });
+
+            // Process columns (Y-direction) in parallel
+            // We collect results to avoid concurrent writes to the buffer
+
+            // TODO: "Check if imageproc support concurrent writes"
+            let column_results: Vec<_> = (0..w)
+                .into_par_iter()
+                .map(|x| {
+                    // Note: These are now created inside parallel closures for thread safety
+                    let mut y_envelope = Envelope::new(h);
+                    let mut y_result_buffer = vec![f32::NAN; h];
+
+                    let f = |y: usize| {
+                        if is_feature[y][x] { 0.0 } else { f32::INFINITY }
                     };
 
-                    should_process[y][x] = process_pixel;
+                    let ignore = |y: usize| !should_process[y][x];
 
-                    // Check if this pixel is a feature point
-                    let is_feature_point =
-                        process_pixel && point_set.map_or(false, |ps| ps.contains(&(x, y)));
+                    distance_transform_1d(&f, &mut y_envelope, &mut y_result_buffer, &ignore);
 
-                    is_feature[y][x] = is_feature_point;
-                }
-            }
+                    // Return the column index and results
+                    (x, y_result_buffer)
+                })
+                .collect();
 
-            // Process columns (Y-direction)
-            for x in 0..w {
-                let f = |y: usize| {
-                    if is_feature[y][x] { 0.0 } else { f32::INFINITY }
-                };
-
-                let ignore = |y: usize| !should_process[y][x];
-
-                distance_transform_1d(&f, &mut y_envelope, &mut y_result_buffer, &ignore);
-
-                // Copy column buffer to main buffer
+            // Apply column results to buffer
+            for (x, y_result_buffer) in column_results {
                 for y in 0..h {
                     if should_process[y][x] {
                         buffer.put_pixel(x as u32, y as u32, Luma([y_result_buffer[y]]));
@@ -333,14 +348,25 @@ impl HeightMap {
                 }
             }
 
-            // Process rows (X-direction)
-            for y in 0..h {
-                let f = |x: usize| buffer.get_pixel(x as u32, y as u32).0[0];
-                let ignore = |x: usize| !should_process[y][x];
+            // Process rows (X-direction) in parallel
+            let row_results: Vec<_> = (0..h)
+                .into_par_iter()
+                .map(|y| {
+                    let mut x_envelope = Envelope::new(w);
+                    let mut x_result_buffer = vec![f32::NAN; w];
 
-                distance_transform_1d(&f, &mut x_envelope, &mut x_result_buffer, &ignore);
+                    let f = |x: usize| buffer.get_pixel(x as u32, y as u32).0[0];
+                    let ignore = |x: usize| !should_process[y][x];
 
-                // Copy row buffer to main buffer
+                    distance_transform_1d(&f, &mut x_envelope, &mut x_result_buffer, &ignore);
+
+                    // Return the row index and results
+                    (y, x_result_buffer)
+                })
+                .collect();
+
+            // Apply row results to buffer
+            for (y, x_result_buffer) in row_results {
                 for x in 0..w {
                     if should_process[y][x] {
                         buffer.put_pixel(x as u32, y as u32, Luma([x_result_buffer[x]]));

--- a/src/heightmap.rs
+++ b/src/heightmap.rs
@@ -475,6 +475,10 @@ fn linear_at(
         .sqrt();
 
     let total_distance = distance_to_outer + distance_to_inner;
+    if total_distance == 0.0 {
+        return outer_height;
+    }
+
     let t = distance_to_outer / total_distance;
     return lerp(outer_height, inner_height, t as f32) as i32;
 }

--- a/src/heightmap.rs
+++ b/src/heightmap.rs
@@ -475,7 +475,10 @@ fn linear_at(
         .sqrt();
 
     let total_distance = distance_to_outer + distance_to_inner;
+
     if total_distance == 0.0 {
+        // the pixel is on the contour
+        // return either outer_height or inner_height, they are the same.
         return outer_height;
     }
 

--- a/src/heightmap.rs
+++ b/src/heightmap.rs
@@ -275,7 +275,10 @@ impl HeightMap {
             }
         }
 
-        // TODO: See if these can be reduced. It really takes a lot memory
+        // A map indicating whether a pixel should be processed for the current height level.
+        // This is necessary for better performance because it will be queried twice during
+        // column and row processing. And this should be outside the height loop because we
+        // want to avoid reallocating the vector on each iteration.
         let mut should_process = vec![vec![false; w]; h];
 
         // Loop through each height level.

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ fn main() {
     // Read command line arguments
     let config = get_config();
 
+    println!("Creating contour line tree...");
     let (contour_lines, image_width, image_heihgt) =
         contour_line::get_contour_line_tree_from(&config.file_path);
     println!("Contour lines count = {}", contour_lines.size());


### PR DESCRIPTION
Use `imageproc::distance_transform::euclidean_squared_distance_transform` to boost speed. Generate a distance field for each height of contour lines. Theoretically uses more memory but got a great boost.

On my machine, a 3:40 fill can be reduced to 1:02.