### PR TITLE
 f64 heightmap data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ dependencies = [
  "clap",
  "imageproc",
  "indicatif",
+ "ordered-float",
  "rayon",
  "rstar",
 ]
@@ -824,6 +825,15 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "ordered-float"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "owned_ttf_parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ ab_glyph = "0.2.29"
 indicatif = {version = "0.18.0", features = ["rayon"]}
 rayon = "1.10.0"
 rstar = "0.12.2"
+ordered-float = "5.0.0"

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -13,7 +13,7 @@ pub fn draw_contour_lines_with_text(
 ) {
     for contour_line in contour_lines {
         // Draw all contour line points
-        let points = &contour_line.contour().points;
+        let points = &contour_line.contour.points;
         for point in points {
             image.draw_pixel(point.x as u32, point.y as u32, Rgb::from([255, 0, 0]));
         }
@@ -21,10 +21,7 @@ pub fn draw_contour_lines_with_text(
         // Mark the first point of the contour line with height value
         let point0 = points[0];
         let scale = PxScale::from(24.0);
-        let text = contour_line
-            .height()
-            .expect("Contour line does not have height")
-            .to_string();
+        let text = contour_line.height.to_string();
 
         draw_text_on_center(
             image,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,8 @@ pub struct Args {
     draw_contours: bool,
 
     /// The height gap between contour lines
-    #[arg(short, long, default_value_t = 50)]
-    gap: i32,
+    #[arg(short, long, default_value_t = 50.0)]
+    gap: f64,
 }
 
 pub fn run() {
@@ -65,21 +65,11 @@ pub fn run() {
     let heightmap = match args.fill_mode {
         FillMode::Flat => {
             println!("Using flat fill.");
-            HeightMap::new_flat(
-                contour_lines,
-                args.gap,
-                image_width as usize,
-                image_height as usize,
-            )
+            HeightMap::new_flat(contour_lines, args.gap, image_width, image_height)
         }
         FillMode::Linear => {
             println!("Using linear fill");
-            HeightMap::new_linear(
-                contour_lines,
-                args.gap,
-                image_width as usize,
-                image_height as usize,
-            )
+            HeightMap::new_linear(contour_lines, args.gap, image_width, image_height)
         }
     };
     println!("Heightmap filled in {:?}", start.elapsed());


### PR DESCRIPTION
- Use f64 luma image as heightmap data. Fix #8.
- Add `ordered_float` dependency.
- Fix some code.
Temporarily break `to_rgb_image` function. Will fix with #12.