### PR TITLE
Color mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colorous"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e18bf7a165bf7028fde98609a0f1e8f7498d762a212598e6c891f6893556ec"
+
+[[package]]
 name = "console"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +305,7 @@ version = "0.0.1"
 dependencies = [
  "ab_glyph",
  "clap",
+ "colorous",
  "imageproc",
  "indicatif",
  "ordered-float",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ indicatif = {version = "0.18.0", features = ["rayon"]}
 rayon = "1.10.0"
 rstar = "0.12.2"
 ordered-float = "5.0.0"
+colorous = "1.0.16"


### PR DESCRIPTION
- Fix the rgb color map and support more variety with `colorous` crate. (Fix #12)
- Save u16 grayscale images.